### PR TITLE
chore: rename storage account RG variable

### DIFF
--- a/backend.hcl
+++ b/backend.hcl
@@ -1,6 +1,6 @@
 locals {
   subscription_id        = ""
-  store_account_rg_name  = ""
+  storage_account_rg_name  = ""
   storage_account_name   = ""
   storage_container_name = ""
 }

--- a/root.hcl
+++ b/root.hcl
@@ -3,7 +3,7 @@ locals {
   tenant_id = "" # TODO: Set the tenant_id
 
   backend_vars  = read_terragrunt_config(find_in_parent_folders("backend.hcl"))
-  backend_rg    = local.backend_vars.locals.store_account_rg_name
+  backend_rg    = local.backend_vars.locals.storage_account_rg_name
   backend_sa    = local.backend_vars.locals.storage_account_name
   backend_cont  = local.backend_vars.locals.storage_container_name
   backend_subId = local.backend_vars.locals.subscription_id


### PR DESCRIPTION
## Summary
- rename `store_account_rg_name` local to `storage_account_rg_name`
- update backend variable references

## Testing
- `terraform fmt backend.hcl root.hcl` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*
- `terragrunt hclfmt` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a49fae469c83239d777dc2be4d9ff4