### PR TITLE
chore: fix terragrunt module versioning

### DIFF
--- a/_envcommon/units/avm/default.hcl
+++ b/_envcommon/units/avm/default.hcl
@@ -8,7 +8,8 @@ locals {
 }
 
 terraform {
-  source = "${local.this.source}?version=${local.this.version}"
+  source  = local.this.source
+  version = local.this.version
 }
 
 inputs = {


### PR DESCRIPTION
## Summary
- properly specify module version for AVM units

## Testing
- `terragrunt hclfmt` *(fails: command not found)*
- `apt-get update` *(fails: The repository 'http://archive.ubuntu.com/ubuntu noble InRelease' is not signed (403 Forbidden))*


------
https://chatgpt.com/codex/tasks/task_e_68a49fc9649c8323922d07549b26a4e3