### PR TITLE
docs: fix README module path

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ terragrunt run-all apply --terragrunt-non-interactive
 For running single modules, you can also run `terragrunt plan` or `terragrunt apply` directly like so
 
 ```bash
-cd env/dev/westeurope/001/resourcegroup/app
+cd env/dev/westeurope/001/resourcegroup/network
 terragrunt plan
 terragrunt apply
 ```


### PR DESCRIPTION
## Summary
- fix example path for running single modules

## Testing
- `terraform fmt -recursive -check` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68a49fcfd2008323b78c33d28fe9b1ea